### PR TITLE
Create CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,64 @@
+# Regras de conduta para participantes dos projetos no Training Center
+
+Essas são as regras de conduta para que não aconteça nenhum transtorno por parte dos(as) envolvidos(as) em nossos projetos.
+
+O Training Center é um local aberto a todos e todos devem se sentir confortáveis participando de nossas iniciativas.
+
+Não toleramos nenhum tipo de repúdio, humilhação ou discriminação por:
+
+* Gênero, identidade de gênero ou expressão de gênero;
+* Orientação sexual;
+* Restrições físicas;
+* Aparência física (incluindo, mas não limitado, ao tamanho do corpo);
+* Raça e/ou etnia;
+* Idade;
+* Religião ou a falta dela;
+* Escolha de tecnologias;
+
+Como membro deste grupo, você concorda que:
+
+* Nós somos, coletivamente e individualmente, comprometidos com a segurança e inclusão;
+* Nós adotamos a política de tolerância zero para assédios, perseguições ou discriminações;
+* Nós respeitamos limites, identidade e privacidade das pessoas;
+* Nós nos abstemos de usar linguagem que possa ser considerada opressiva, como comentários sexistas, racistas, homofóbicos, transfóbicos, classistas ou que discrimine pessoas com qualquer tipo de deficiência, mas este Código de Conduta não está limitado a apenas estes;
+* Nós evitamos tópicos ofensivos como forma de humor.
+
+Nós trabalhamos ativamente para:
+
+* Ser uma comunidade segura;
+* Cultivar uma rede de suporte e encorajamento para todos;
+* Encorajar variadas formas de expressão de maneira responsável.
+
+Nós condenamos:
+
+* Perseguição, _doxxing_ (investigar a vida de uma pessoa sem autorização) ou publicações indevidas de informações privadas;
+* Ameaça e assédio de qualquer tipo;
+* Qualquer comportamento que comprometa a segurança dos demais membros.
+
+**Essas atitudes NÃO SÃO CORRETAS.** Se você não concorda com estas regras, por favor, cancele sua inscrição neste grupo.
+
+O desrespeito às regras desta comunidade, descritas nesse documento, acarretará em consequências:
+
+- Publicações que não estiverem de acordo com este Código de Conduta serão removidas;
+- Cabe aos moderadores decidir se você será removido temporariamente ou permanentemente deste grupo.
+
+**Se você sofrer algum tipo de abuso, assédio, discriminação ou se sentir inseguro, fale com um moderador. Se o moderador for a pessoa que você quer reportar, fale com outro moderador.**
+
+*A posição de moderador é para fins de moderação imparcial; eles não vão moderar ou editar o conteúdo postado pelos membros do grupo para outras finalidades ou por motivos estritamente pessoais.*
+
+## Moderadores
+
+* [Ademílson F. Tonato](https://github.com/ftonato)
+* [Aline Bastos](https://github.com/alinebastos)
+* [Danilo Vaz](https://github.com/danilovaz)
+* [Gil Vieira](https://github.com/ogilvieira)
+* [Jamile Lima](https://github.com/JamileLima)
+* [Luiz Paulo "Bills"](https://github.com/luizbills)
+* [Ramon Sanches](https://github.com/raymonsanches)
+* [William Oliveira](https://github.com/woliveiras)
+
+---
+
+*Esse texto é um documento em constante edição, e pode ser alterado no futuro.*
+
+Código de conduta baseado em: https://github.com/fnando/codigo-de-conduta, https://github.com/AndroidDevBR/Codigo-De-Conduta


### PR DESCRIPTION
Essa semana o GitHub lançou um local especifico para colocar o código de conduta de projetos open source, só miguei o código de conduta atual para o modelo sugerido pela equipe do GitHub.